### PR TITLE
Changed deployer.in to deployer.org since deployer.in domain is expired

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 deployer.in
 ===============
 
-[deployer.in](http://deployer.in/) is a deployment tool written in PHP, it's simple and functional. Deploy your code to all servers you want, it supports deploy via copy, or via VCS (like git), or via rsync. Run your tasks on all your servers, or use our recipes of common tasks for Symfony, Laravel, Zend Framework and Yii.
+[deployer.org](http://deployer.org/) is a deployment tool written in PHP, it's simple and functional. Deploy your code to all servers you want, it supports deploy via copy, or via VCS (like git), or via rsync. Run your tasks on all your servers, or use our recipes of common tasks for Symfony, Laravel, Zend Framework and Yii.
 
 Requirements
 ------------
@@ -11,7 +11,7 @@ PHP 5.4.0 and up.
 Role Variables
 --------------
 
-* deployer_in_url : http://deployer.in/deployer.phar
+* deployer_in_url : http://deployer.org/deployer.phar
 * deployer_in_path: /usr/local/bin/dep
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-deployer_in_url : http://deployer.in/deployer.phar
+deployer_in_url : http://deployer.org/deployer.phar
 deployer_in_path: /usr/local/bin/dep

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,13 +3,16 @@
 galaxy_info:
   author: Joeri Verdeyen
   company: jverdeyen.be
-  description: An Ansible role to install deployer.in
+  description: An Ansible role to install deployer.org
   min_ansible_version: 1.4
   license: MIT
   platforms:
   - name: Ubuntu
     versions:
     - all
+  - name: Debian
+    versions:
+    - wheezy
   categories:
   - system
 


### PR DESCRIPTION
Since deployer.in is pretty much offline, it's better to remove all references to this old domain. I've also updated the meta info, as this role runs pretty fine on Debian Wheezy.
